### PR TITLE
Build and install gtk thumbnail

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,9 +4,11 @@ Priority: optional
 Maintainer: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
 Build-Depends: debhelper-compat (= 13)
 Build-Depends-Indep: libglib2.0-dev,
-                     meson (>= 0.61),
+                     meson (>= 1.3.0),
                      sassc,
-                     python3
+                     python3,
+                     inkscape,
+                     optipng,
 Standards-Version: 4.6.0
 Homepage: https://hsbasu.github.io/sucharu
 Vcs-Browser: https://github.com/mamolinux/sucharu

--- a/gtk/src/data/thumbnail-dark.svg
+++ b/gtk/src/data/thumbnail-dark.svg
@@ -2,12 +2,12 @@
  <path x="9.5367432e-06" y="0" width="127.99999" height="40" d="m1.3229 0h125.35a1.3229 1.3229 45 0 1 1.3229 1.3229v37.354a1.3229 1.3229 135 0 1-1.3229 1.3229h-125.35a1.3229 1.3229 45 0 1-1.3229-1.3229v-37.354a1.3229 1.3229 135 0 1 1.3229-1.3229z" fill="#404040" stroke-width=".11393"/>
  <g>
   <rect x="105" y="10" width="20" height="20" color="#000000" fill="none"/>
-  <rect x="106.25" y="11.25" width="17.5" height="17.5" rx="8.75" ry="8.75" color="#000000" fill="#00ff02" stroke-width="0"/>
+  <rect x="106.25" y="11.25" width="17.5" height="17.5" rx="8.75" ry="8.75" color="#000000" fill="#00ff01" stroke-width="0"/>
   <rect x="112.5" y="17.5" width="5" height="5" rx="2.4986" ry="2.5" color="#000000" fill="#fff"/>
  </g>
  <rect x="80" y="10" width="20" height="20" rx="1" ry="1" fill="none" stroke-width="0"/>
- <rect x="82" y="12" width="16" height="16" rx="1" ry="1" fill="#00ff02" stroke-width="3.7795"/>
+ <rect x="82" y="12" width="16" height="16" rx="1" ry="1" fill="#00ff01" stroke-width="3.7795"/>
  <path d="m93.578 15.781-4.7656 4.7813-2.3906-2.3906-1.5938 1.5938 2.3907 2.3906 1.5938 1.5937 1.5781-1.5937 4.7813-4.7813z" fill="#fff"/>
- <path x="5.2500038" y="4.2499928" width="67.620514" height="31.50001" d="m5.7792 4.25h66.562a0.52917 0.52917 45 0 1 0.52917 0.52917v30.442a0.52917 0.52917 135 0 1-0.52917 0.52917h-66.562a0.52917 0.52917 45 0 1-0.52917-0.52917v-30.442a0.52917 0.52917 135 0 1 0.52917-0.52917z" fill="#6b6b6b" fill-opacity=".6" stroke="#00ff02" stroke-linejoin="round" stroke-width=".26458" style="paint-order:normal"/>
+ <path x="5.2500038" y="4.2499928" width="67.620514" height="31.50001" d="m5.7792 4.25h66.562a0.52917 0.52917 45 0 1 0.52917 0.52917v30.442a0.52917 0.52917 135 0 1-0.52917 0.52917h-66.562a0.52917 0.52917 45 0 1-0.52917-0.52917v-30.442a0.52917 0.52917 135 0 1 0.52917-0.52917z" fill="#6b6b6b" fill-opacity=".6" stroke="#ff0001" stroke-linejoin="round" stroke-width=".26458" style="paint-order:normal"/>
  <text x="7.5152493" y="26.73324" fill="#ffffff" fill-opacity=".87" font-family="sans-serif" font-size="18.838px" stroke-width="1.1774" style="line-height:1.25" xml:space="preserve"><tspan x="7.5152493" y="26.73324" fill="#ffffff" fill-opacity=".87" font-size="18.838px" stroke-width="1.1774">Button</tspan></text>
 </svg>

--- a/gtk/src/data/thumbnail.svg
+++ b/gtk/src/data/thumbnail.svg
@@ -2,14 +2,14 @@
  <path x="-2.220446e-16" y="-4.4408921e-16" width="33.866665" height="10.583333" d="m4.9999 0h118a4.9999 5 0 0 1 4.9999 5v30a4.9999 5 0 0 1-4.9999 5h-118a4.9999 5 0 0 1-4.9999-5v-30a4.9999 5 0 0 1 4.9999-5z" fill="#f5f5f5" stroke-width=".4306"/>
  <g transform="scale(3.7795)">
   <rect x="27.781" y="2.6458" width="5.2917" height="5.2917" color="#000000" fill="none"/>
-  <rect x="28.112" y="2.9766" width="4.6302" height="4.6302" rx="2.3151" ry="2.3151" color="#000000" fill="#00ff02"/>
+  <rect x="28.112" y="2.9766" width="4.6302" height="4.6302" rx="2.3151" ry="2.3151" color="#000000" fill="#00ff01"/>
   <rect x="29.766" y="4.6302" width="1.3229" height="1.3229" rx=".66109" ry=".66146" color="#000000" fill="#fff"/>
  </g>
  <rect x="80.001" y="9.9999" width="20" height="20" rx=".99998" ry=".99999" fill="none" stroke-width="0"/>
  <g transform="scale(3.7795)">
-  <rect x="21.696" y="3.175" width="4.2333" height="4.2333" rx=".26458" ry=".26458" fill="#00ff02"/>
+  <rect x="21.696" y="3.175" width="4.2333" height="4.2333" rx=".26458" ry=".26458" fill="#00ff01"/>
   <path d="m24.759 4.1755-1.2609 1.265-0.63251-0.63252-0.42169 0.42168 0.63253 0.63252 0.42168 0.42168 0.41754-0.42168 1.2651-1.265z" fill="#fff"/>
-  <path x="1.389061" y="1.1244774" width="17.89126" height="8.3343773" d="m1.9182 1.1245h16.833a0.52917 0.52917 45 0 1 0.52917 0.52917v7.276a0.52917 0.52917 135 0 1-0.52917 0.52917h-16.833a0.52917 0.52917 45 0 1-0.52917-0.52917v-7.276a0.52917 0.52917 135 0 1 0.52917-0.52917z" fill="#fafafa" stroke="#00ff02" stroke-linejoin="round" stroke-width=".26458" style="paint-order:normal"/>
+  <path x="1.389061" y="1.1244774" width="17.89126" height="8.3343773" d="m1.9182 1.1245h16.833a0.52917 0.52917 45 0 1 0.52917 0.52917v7.276a0.52917 0.52917 135 0 1-0.52917 0.52917h-16.833a0.52917 0.52917 45 0 1-0.52917-0.52917v-7.276a0.52917 0.52917 135 0 1 0.52917-0.52917z" fill="#fafafa" stroke="#ff0001" stroke-linejoin="round" stroke-width=".26458" style="paint-order:normal"/>
   <text x="1.9884071" y="7.0731697" color="#000000" fill="#000000" font-family="sans-serif" font-size="4.9843px" stroke-width=".31152" style="line-height:1.25" xml:space="preserve"><tspan x="1.9884071" y="7.0731697" font-size="4.9843px" stroke-width=".31152">Button</tspan></text>
  </g>
 </svg>

--- a/gtk/src/default/gtk-3.0/sass/_colors.scss
+++ b/gtk/src/default/gtk-3.0/sass/_colors.scss
@@ -20,7 +20,7 @@ $selected_bg_color: $accent_bg_color;
 
 $selected_fg_color: $accent_fg_color;
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color,8%));
+$borders_color: if($variant == 'light', darken($bg_color, 10%), lighten($bg_color,8%));
 $separator_color: if($variant == 'light', #dfdfdf, darken($bg_color, 6%));
 
 $link_color: #5294e2;

--- a/gtk/src/install-thumbnail.py
+++ b/gtk/src/install-thumbnail.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+# rename and install gtk thumbnails for cinnamon
+
+import os
+import sys
+
+PREFIX = os.environ.get('MESON_INSTALL_DESTDIR_PREFIX', '/usr')
+svg_src = sys.argv[1]
+png_dir = os.path.join(PREFIX, sys.argv[2])
+svg_dir = os.path.dirname(svg_src)
+png_thumb = os.path.join(svg_dir, 'thumbnail.png')
+
+if __name__ == '__main__':
+	os.makedirs(png_dir, exist_ok=True)
+	os.system('inkscape %s -o %s --export-dpi=192' % (svg_src, png_thumb))
+	os.system('optipng -o7 %s' % png_thumb)
+	os.system('cp -uv %s %s' % (png_thumb, os.path.join(png_dir, 'thumbnail.png')))

--- a/gtk/src/meson.build
+++ b/gtk/src/meson.build
@@ -6,7 +6,7 @@ gtk_versions = [
 
 gtk_sucharu_colors_defs = {}
 sass_global_paths = ['-I', meson.project_source_root() / 'common']
-message('\n\tAll flavours: @0@'.format(flavours))
+message('All flavours: @0@\n'.format(flavours))
 
 foreach flavour: flavours
   suffix = flavour == 'default' ? '' : '-@0@'.format(flavour)
@@ -65,20 +65,14 @@ foreach flavour: flavours
     message('Working on GTK version ' + gtk_ver)
     gtk_dir = 'gtk-@0@'.format(gtk_ver)
     base_path = (flavour.startswith('mate') ? base_theme_name : 'default') / gtk_dir
-    dark_path = is_dark ? 'dark' : base_path
     default_path = 'default' / gtk_dir
     upstream_path = '..' / 'upstream' / gtk_dir / 'Yaru'
-    # flavour_path = join_paths(flavour, gtk_dir)
     flavour_path = join_paths('flavours', accent, gtk_dir)
-    message('flavour_path : ' + flavour_path+'\n')
-    message('base_path : ' + base_path+'\n')
     install_path = theme_dir / gtk_dir
 
     # Sort by most relevant for the theme flavour
     sources_priority = [
       flavour_path,
-      dark_path,
-      base_path,
       default_path,
       upstream_path,
     ]
@@ -147,41 +141,41 @@ foreach flavour: flavours
     endforeach
 
     # if is_accent
-      gtk_accents_css = configure_file(
-        configuration: accent_configuration + {
-          'sucharu_theme_entry_point': meson.current_source_dir() / gtk_scss_path,
-        },
-        input: accent_colors_definitions_scss,
-        output: '@0@-accent-colors.scss'.format(target_name),
-      )
+    gtk_accents_css = configure_file(
+      configuration: accent_configuration + {
+        'sucharu_theme_entry_point': meson.current_source_dir() / gtk_scss_path,
+      },
+      input: accent_colors_definitions_scss,
+      output: '@0@-accent-colors.scss'.format(target_name),
+    )
 
-      gtk_scss_path = gtk_accents_css
+    gtk_scss_path = gtk_accents_css
 
-      gtk_sucharu_colors_defs_scss = configure_file(
-        configuration: accent_configuration + {
-          'sucharu_theme_entry_point': sucharu_colors_defs_scss,
-        },
-        input: accent_colors_definitions_scss,
-        output: '@0@-sucharu-colors-defs.scss'.format(target_name),
-      )
+    gtk_sucharu_colors_defs_scss = configure_file(
+      configuration: accent_configuration + {
+        'sucharu_theme_entry_point': sucharu_colors_defs_scss,
+      },
+      input: accent_colors_definitions_scss,
+      output: '@0@-sucharu-colors-defs.scss'.format(target_name),
+    )
 
-      sucharu_gtk_colors_defs = custom_target(
-        '@0@-sucharu-colors-definitions'.format(target_name),
-        input: gtk_sucharu_colors_defs_scss,
-        output: '@BASENAME@.css',
-        command: [
-          sassc, '-a',
-          scss_paths,
-          '@INPUT@', '@OUTPUT@',
-        ],
-        depend_files: [
-          sucharu_colors_defs_scss,
-          gtk_scss_dependencies,
-        ]
-      )
+    sucharu_gtk_colors_defs = custom_target(
+      '@0@-sucharu-colors-definitions'.format(target_name),
+      input: gtk_sucharu_colors_defs_scss,
+      output: '@BASENAME@.css',
+      command: [
+        sassc, '-a',
+        scss_paths,
+        '@INPUT@', '@OUTPUT@',
+      ],
+      depend_files: [
+        sucharu_colors_defs_scss,
+        gtk_scss_dependencies,
+      ]
+    )
     # endif
     if gtk_ver == '3.0'
-      gtk_sucharu_colors_defs += {target_name: sucharu_gtk_colors_defs}
+      gtk_sucharu_colors_defs += {theme_full_name: sucharu_gtk_colors_defs}
     endif
     
     generated_css += custom_target(target_name,
@@ -246,16 +240,40 @@ foreach flavour: flavours
   endforeach
 
   if get_option('cinnamon-shell')
-    message('Building thumbnail for: '+theme_full_name)
+    message('Building thumbnail for: @0@\n'.format(flavour))
     # install thumbnail (cinnamon only)
+    colors_definitions = gtk_sucharu_colors_defs['@0@'.format(theme_full_name)]
     if is_dark
-      inputfile = 'data/thumbnail-dark.svg'
-    # elif is_darker
-    #   inputfile = 'data/thumbnail-darker.svg'
+      inputfile = meson.current_source_dir() + '/data/thumbnail-dark.svg'
     else
-      inputfile = 'data/thumbnail.svg'
+      inputfile = meson.current_source_dir() + '/data/thumbnail.svg'
     endif
-    svg_target_name = theme_full_name + '-' + 'thumbnail'
+    basename = join_paths(flavour, 'gtk-3.0', fs.stem(inputfile))
+    if flavour == 'default'
+      svg_target_name = fs.stem(basename) + '.svg'
+      svg_src = join_paths(meson.current_build_dir(), '@0@.svg'.format(basename))
+    else
+      svg_target_name = fs.stem(basename) + '-' + flavour + '.svg'
+      svg_src = join_paths(meson.current_build_dir(), '@0@-@1@.svg'.format(basename, flavour))
+    endif
+    
+    accented_thumbnail_svg = custom_target(
+      '___'.join('@0@'.format(svg_target_name).split('/')),
+      input: inputfile,
+      output: '@BASENAME@-@0@.svg'.format(flavour),
+      command: [
+        colorize_dummy_svg,
+        colors_definitions,
+        '--input-file', '@INPUT@',
+        '--output-folder', '@OUTDIR@'+'/@0@/@1@'.format(flavour, 'gtk-3.0'),
+        '--variant', flavour,
+      ],
+      depends: colors_definitions,
+      build_by_default: true,
+    )
+
+    png_dir = join_paths(theme_dir, 'gtk-3.0')
+    meson.add_install_script('install-thumbnail.py', svg_src, png_dir)
   endif
 endforeach
 

--- a/gtk/src/post_install.py
+++ b/gtk/src/post_install.py
@@ -39,7 +39,7 @@ for f in flavours:
             move(theme_gresource_src, theme_gresource_dst)
 
         # rename css
-        for variant in ['', '-dark', '-darker']:
+        for variant in ['', '-dark']:
             theme_gtk_css = "{flavour}-gtk{variant}-{ver}.css".format(flavour=flavour_name, ver=gtkver, variant=variant)
             theme_gtk_css_src = path.join(gtk_dir, theme_gtk_css)
             if path.exists(theme_gtk_css_src):


### PR DESCRIPTION
- Build and install gtk thumbnail for cinnamon desktop
- Remove darker variant from build scripts
- Add svg thumbnail template
- Add inkscape and optipng as dependency